### PR TITLE
docs: Add merge strategy documentation for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,362 @@
+# AI Agent Merge Strategy Documentation
+
+## Purpose
+
+This document provides instructions for AI agents (Claude, Copilot, Cursor, Aider, etc.) when performing merge operations on this repository. This is a **fork** with specific customizations that must be preserved.
+
+---
+
+## Repository Context
+
+- **Fork**: `darkspadez/sysext-bakery`
+- **Upstream**: Original sysext-bakery repository
+- **Fork Hub**: `sysext.darkspadez.me`
+- **Customization Commit**: `939ef0ac6144eeb90e1ae357d00aed3d560c118f`
+
+This fork has been customized to:
+1. Ship **Docker ONLY** (without standalone containerd/runc)
+2. Use **EROFS** filesystem format by default (not squashfs)
+3. Maintain fork-specific identity and versions
+
+---
+
+## Protected Files and Patterns
+
+### MUST PRESERVE: .env File
+
+**File**: `.env`
+
+**Content**:
+```bash
+bakery="darkspadez/sysext-bakery"
+bakery_hub="sysext.darkspadez.me"
+```
+
+**Rules**:
+- This file must always exist
+- These two variables must always have these exact values
+- If upstream adds `.env`, merge contents but keep these variables unchanged
+
+---
+
+### MUST PRESERVE: Docker-Only Build Logic
+
+**File**: `docker.sysext/create.sh`
+
+**Function**: `populate_sysext_root()`
+
+**Critical Code Block**:
+```bash
+announce "Removing containerd / runc from sysext as requested (shipping docker only)"
+
+rm "${sysextroot}/usr/bin/containerd" \
+    "${sysextroot}/usr/bin/containerd-shim-runc-v2" \
+    "${sysextroot}/usr/bin/ctr" \
+    "${sysextroot}/usr/bin/runc"
+```
+
+**Context**:
+- Upstream version has conditional logic with `--without docker` or `--without containerd` options
+- This fork has **removed that conditional logic** permanently
+- The function always removes containerd/runc binaries
+
+**Rules**:
+- Never reintroduce the `if [[ "${without}" == docker ]]` conditional blocks
+- Always keep the simplified Docker-only removal logic
+- If upstream adds new containerd binaries, add them to the removal list
+
+---
+
+### MUST DELETE: Containerd Service Files
+
+The following files were deleted in the fork and **must never be restored**:
+
+```
+docker.sysext/files/usr/lib/systemd/system/containerd.service
+docker.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-containerd-service.conf
+docker.sysext/files/usr/share/containerd/config.toml
+docker.sysext/files/usr/share/containerd/config-cgroupfs.toml
+```
+
+**Rules**:
+- If these files appear during a merge from upstream, **delete them after merging**
+- Do not keep containerd as a systemd service in this fork
+- These files are incompatible with the Docker-only strategy
+
+---
+
+### MUST PRESERVE: EROFS Default Format
+
+**File**: `lib/generate.sh`
+
+**Function**: `generate_sysext()`
+
+**Critical Line**:
+```bash
+local format="$(get_optional_param "format" "erofs" "${@}")"
+```
+
+**Context**:
+- Upstream default is `squashfs`
+- This fork uses `erofs` as the default
+
+**Rules**:
+- When merging changes to `generate_sysext()`, ensure the default format parameter remains `erofs`
+- Do not revert to `squashfs` unless explicitly requested by the fork maintainer
+
+---
+
+### MUST PRESERVE: Custom Release Versions
+
+**File**: `release_build_versions.txt`
+
+**Fork-Specific Entries**:
+```
+docker 28.2.1
+tailscale v1.84.0
+```
+
+**Rules**:
+- These versions are specific to this fork's needs
+- When merging upstream changes, preserve these version entries
+- If upstream adds newer versions, keep both sets (fork + upstream)
+- Maintain alphabetical/version ordering
+
+---
+
+## Automated Merge Procedure
+
+When instructed to merge from upstream, follow these steps:
+
+### 1. Pre-Merge State Capture
+```bash
+# Store current protected content
+cp .env .env.fork-backup
+cp docker.sysext/create.sh create.sh.fork-backup
+cp lib/generate.sh generate.sh.fork-backup
+cp release_build_versions.txt versions.fork-backup
+```
+
+### 2. Perform Merge
+```bash
+git fetch upstream main
+git merge upstream/main
+```
+
+### 3. Automatic Conflict Resolution Rules
+
+For each conflict, apply these resolution strategies:
+
+#### .env Conflicts
+```
+Strategy: MERGE + PRESERVE
+- Accept all upstream additions
+- Ensure fork variables are present:
+  bakery="darkspadez/sysext-bakery"
+  bakery_hub="sysext.darkspadez.me"
+```
+
+#### docker.sysext/create.sh Conflicts
+```
+Strategy: PRESERVE FORK LOGIC
+- Review upstream changes for bug fixes/security patches
+- Apply fixes while maintaining Docker-only removal logic
+- Do NOT reintroduce conditional --without logic
+- Final code must always remove: containerd, containerd-shim-runc-v2, ctr, runc
+```
+
+#### lib/generate.sh Conflicts
+```
+Strategy: ACCEPT UPSTREAM + OVERRIDE DEFAULT
+- Accept upstream changes
+- Ensure format default is "erofs" not "squashfs"
+```
+
+#### release_build_versions.txt Conflicts
+```
+Strategy: UNION
+- Include both upstream and fork versions
+- Sort appropriately
+- Keep: docker 28.2.1, tailscale v1.84.0
+```
+
+### 4. Post-Merge Validation
+
+Run these checks automatically:
+
+```bash
+# Check 1: .env exists with correct variables
+grep -q 'bakery="darkspadez/sysext-bakery"' .env || echo "VALIDATION FAILED: .env missing fork bakery"
+grep -q 'bakery_hub="sysext.darkspadez.me"' .env || echo "VALIDATION FAILED: .env missing fork hub"
+
+# Check 2: Docker-only logic present
+grep -q 'Removing containerd / runc from sysext as requested (shipping docker only)' docker.sysext/create.sh || echo "VALIDATION FAILED: Docker-only message missing"
+
+# Check 3: No conditional --without logic
+grep -q 'if \[\[ "${without}" ==' docker.sysext/create.sh && echo "VALIDATION FAILED: Conditional logic reintroduced"
+
+# Check 4: Containerd files deleted
+[ -f docker.sysext/files/usr/lib/systemd/system/containerd.service ] && echo "VALIDATION FAILED: containerd.service exists"
+[ -f docker.sysext/files/usr/share/containerd/config.toml ] && echo "VALIDATION FAILED: containerd config exists"
+
+# Check 5: Default format is erofs
+grep -q 'format="$(get_optional_param "format" "erofs"' lib/generate.sh || echo "VALIDATION FAILED: Default format not erofs"
+
+# Check 6: Custom versions present
+grep -q "docker 28.2.1" release_build_versions.txt || echo "VALIDATION FAILED: docker 28.2.1 missing"
+grep -q "tailscale v1.84.0" release_build_versions.txt || echo "VALIDATION FAILED: tailscale v1.84.0 missing"
+```
+
+### 5. Auto-Fix Validation Failures
+
+If any validation fails, apply automatic fixes:
+
+```bash
+# Fix .env
+if ! grep -q 'bakery="darkspadez/sysext-bakery"' .env; then
+  echo 'bakery="darkspadez/sysext-bakery"' >> .env
+fi
+if ! grep -q 'bakery_hub="sysext.darkspadez.me"' .env; then
+  echo 'bakery_hub="sysext.darkspadez.me"' >> .env
+fi
+
+# Fix containerd files (delete if they exist)
+rm -f docker.sysext/files/usr/lib/systemd/system/containerd.service
+rm -f docker.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-containerd-service.conf
+rm -f docker.sysext/files/usr/share/containerd/config.toml
+rm -f docker.sysext/files/usr/share/containerd/config-cgroupfs.toml
+
+# If docker.sysext/create.sh has wrong logic, restore from fork backup
+if grep -q 'if \[\[ "${without}" ==' docker.sysext/create.sh; then
+  # Restore fork version and re-apply upstream changes manually
+  echo "WARNING: Conditional logic detected in create.sh - manual review needed"
+fi
+
+# Fix format default in lib/generate.sh
+sed -i 's/format="$(get_optional_param "format" "squashfs"/format="$(get_optional_param "format" "erofs"/' lib/generate.sh
+```
+
+---
+
+## Decision Tree for Conflicts
+
+```
+Is this a merge from upstream?
+├─ YES → Apply fork preservation rules
+│   │
+│   ├─ File: .env
+│   │   └─ Keep fork variables, accept upstream additions
+│   │
+│   ├─ File: docker.sysext/create.sh
+│   │   └─ Preserve Docker-only logic, reject conditional --without logic
+│   │
+│   ├─ File: lib/generate.sh
+│   │   └─ Keep erofs as default format
+│   │
+│   ├─ File: release_build_versions.txt
+│   │   └─ Union merge (keep fork + upstream versions)
+│   │
+│   └─ Files: containerd services/configs
+│       └─ DELETE if present
+│
+└─ NO → Standard merge procedure
+```
+
+---
+
+## Commit Message Template
+
+After merging and fixing conflicts:
+
+```
+Merge upstream/main while preserving fork customizations
+
+Preserved fork customizations:
+- .env fork identity (darkspadez/sysext-bakery)
+- Docker-only build logic in docker.sysext/create.sh
+- EROFS default format in lib/generate.sh
+- Custom release versions (docker 28.2.1, tailscale v1.84.0)
+- Removed reintroduced containerd service files
+
+Applied upstream changes:
+- [List significant upstream changes merged]
+
+Validation: All post-merge checks passed
+
+Reference: Fork customizations from 939ef0ac6144eeb90e1ae357d00aed3d560c118f
+```
+
+---
+
+## Error Recovery
+
+If fork customizations are lost after a merge:
+
+```bash
+# Restore from original customization commit
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f:.env > .env
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f:docker.sysext/create.sh > docker.sysext/create.sh
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f:lib/generate.sh > lib/generate.sh
+
+# Remove containerd files
+find docker.sysext/files -name "*containerd*" -delete
+
+# Commit the restoration
+git add .
+git commit -m "Restore fork customizations lost during merge
+
+Reference: 939ef0ac6144eeb90e1ae357d00aed3d560c118f"
+```
+
+---
+
+## Agent-Specific Notes
+
+### For Claude
+- This fork's design philosophy: Docker-only, EROFS format, custom identity
+- Always validate post-merge before committing
+- If uncertain, preserve fork customization over upstream change
+
+### For GitHub Copilot / Cursor
+- Treat patterns in protected files as "required" not "suggested"
+- Do not auto-complete with upstream patterns
+- Flag conflicts in protected files for manual review
+
+### For Aider
+- Use "preserve fork" mode when merging
+- Protected files should have higher precedence than upstream
+- Auto-apply validation fixes before committing
+
+### For Any Agent
+- The fork's purpose is specific: Docker-only builds with EROFS
+- Upstream compatibility is secondary to fork customizations
+- When in doubt, check commit `939ef0ac6144eeb90e1ae357d00aed3d560c118f`
+
+---
+
+## Summary Checklist
+
+After any merge operation, verify:
+
+- [ ] `.env` exists with `bakery="darkspadez/sysext-bakery"` and `bakery_hub="sysext.darkspadez.me"`
+- [ ] `docker.sysext/create.sh` contains Docker-only removal logic (no conditional --without)
+- [ ] `lib/generate.sh` has default format as `erofs` (not squashfs)
+- [ ] `release_build_versions.txt` includes `docker 28.2.1` and `tailscale v1.84.0`
+- [ ] No containerd systemd service files exist in `docker.sysext/files/`
+- [ ] No containerd config files exist in `docker.sysext/files/`
+- [ ] Build test passes: `./build.sh docker latest`
+
+**All checks must pass before pushing merged changes.**
+
+---
+
+## Contact
+
+If you are an AI agent encountering an ambiguous merge scenario not covered by this document:
+
+1. Consult `CLAUDE.md` for additional context
+2. Examine commit `939ef0ac6144eeb90e1ae357d00aed3d560c118f` directly
+3. Default to preserving fork customizations
+4. Request human review if critical upstream changes conflict with fork philosophy
+
+**The fork exists for a specific purpose. Maintain that purpose through all merges.**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,24 +106,6 @@ local format="$(get_optional_param "format" "erofs" "${@}")"
 
 ---
 
-### MUST PRESERVE: Custom Release Versions
-
-**File**: `release_build_versions.txt`
-
-**Fork-Specific Entries**:
-```
-docker 28.2.1
-tailscale v1.84.0
-```
-
-**Rules**:
-- These versions are specific to this fork's needs
-- When merging upstream changes, preserve these version entries
-- If upstream adds newer versions, keep both sets (fork + upstream)
-- Maintain alphabetical/version ordering
-
----
-
 ## Automated Merge Procedure
 
 When instructed to merge from upstream, follow these steps:
@@ -172,14 +154,6 @@ Strategy: ACCEPT UPSTREAM + OVERRIDE DEFAULT
 - Ensure format default is "erofs" not "squashfs"
 ```
 
-#### release_build_versions.txt Conflicts
-```
-Strategy: UNION
-- Include both upstream and fork versions
-- Sort appropriately
-- Keep: docker 28.2.1, tailscale v1.84.0
-```
-
 ### 4. Post-Merge Validation
 
 Run these checks automatically:
@@ -201,10 +175,6 @@ grep -q 'if \[\[ "${without}" ==' docker.sysext/create.sh && echo "VALIDATION FA
 
 # Check 5: Default format is erofs
 grep -q 'format="$(get_optional_param "format" "erofs"' lib/generate.sh || echo "VALIDATION FAILED: Default format not erofs"
-
-# Check 6: Custom versions present
-grep -q "docker 28.2.1" release_build_versions.txt || echo "VALIDATION FAILED: docker 28.2.1 missing"
-grep -q "tailscale v1.84.0" release_build_versions.txt || echo "VALIDATION FAILED: tailscale v1.84.0 missing"
 ```
 
 ### 5. Auto-Fix Validation Failures
@@ -253,9 +223,6 @@ Is this a merge from upstream?
 │   ├─ File: lib/generate.sh
 │   │   └─ Keep erofs as default format
 │   │
-│   ├─ File: release_build_versions.txt
-│   │   └─ Union merge (keep fork + upstream versions)
-│   │
 │   └─ Files: containerd services/configs
 │       └─ DELETE if present
 │
@@ -275,7 +242,6 @@ Preserved fork customizations:
 - .env fork identity (darkspadez/sysext-bakery)
 - Docker-only build logic in docker.sysext/create.sh
 - EROFS default format in lib/generate.sh
-- Custom release versions (docker 28.2.1, tailscale v1.84.0)
 - Removed reintroduced containerd service files
 
 Applied upstream changes:
@@ -341,7 +307,6 @@ After any merge operation, verify:
 - [ ] `.env` exists with `bakery="darkspadez/sysext-bakery"` and `bakery_hub="sysext.darkspadez.me"`
 - [ ] `docker.sysext/create.sh` contains Docker-only removal logic (no conditional --without)
 - [ ] `lib/generate.sh` has default format as `erofs` (not squashfs)
-- [ ] `release_build_versions.txt` includes `docker 28.2.1` and `tailscale v1.84.0`
 - [ ] No containerd systemd service files exist in `docker.sysext/files/`
 - [ ] No containerd config files exist in `docker.sysext/files/`
 - [ ] Build test passes: `./build.sh docker latest`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,24 +85,6 @@ local format="$(get_optional_param "format" "erofs" "${@}")"
 
 ---
 
-### 5. Custom Release Versions
-
-**File: `release_build_versions.txt`**
-
-Additional versions added to the build manifest:
-
-```
-docker 28.2.1
-tailscale v1.84.0
-```
-
-**Merge Rule:**
-- When merging upstream changes to this file, preserve these specific version entries
-- If upstream adds newer versions of docker/tailscale, keep both the fork-specific versions AND the upstream versions
-- These versions may be unique to this fork's needs
-
----
-
 ## Merge Workflow Instructions
 
 When merging from upstream, follow this procedure:
@@ -153,12 +135,6 @@ test -f docker.sysext/files/usr/share/containerd/config.toml && echo "ERROR: con
 grep 'format="$(get_optional_param "format" "erofs"' lib/generate.sh || echo "WARNING: Default format is not erofs!"
 ```
 
-#### Check 5: Custom versions present
-```bash
-grep "docker 28.2.1" release_build_versions.txt || echo "WARNING: docker 28.2.1 missing!"
-grep "tailscale v1.84.0" release_build_versions.txt || echo "WARNING: tailscale v1.84.0 missing!"
-```
-
 ### Step 4: Fix Any Violations
 
 If any checks fail, manually restore the fork customizations before committing the merge.
@@ -188,11 +164,6 @@ If any checks fail, manually restore the fork customizations before committing t
 2. Evaluate if erofs should remain the default for this fork
 3. Unless there's a compelling reason, KEEP erofs as default
 
-### If Upstream Modified release_build_versions.txt
-1. Accept upstream additions
-2. Ensure fork-specific versions (docker 28.2.1, tailscale v1.84.0) are preserved
-3. Sort the file appropriately with both upstream and fork versions
-
 ---
 
 ## Commit Message Format
@@ -206,7 +177,6 @@ Merge upstream/main while preserving fork customizations
 - Preserved Docker-only build in docker.sysext/create.sh
 - Removed reintroduced containerd service files
 - Maintained erofs as default format
-- Preserved custom release versions
 
 Fork customizations from: 939ef0ac6144eeb90e1ae357d00aed3d560c118f
 ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,262 @@
+# Claude AI Merge Strategy Guide
+
+## Critical Fork Customizations
+
+This repository is a fork of the upstream sysext-bakery with specific customizations that **MUST BE PRESERVED** during all merge operations. The customizations were implemented in commit `939ef0ac6144eeb90e1ae357d00aed3d560c118f`.
+
+## Protected Changes - DO NOT REVERT
+
+### 1. Fork Identity (.env)
+
+**File: `.env`**
+
+This file defines the fork's identity and must always exist with these exact values:
+
+```bash
+bakery="darkspadez/sysext-bakery"
+bakery_hub="sysext.darkspadez.me"
+```
+
+**Merge Rule:**
+- If upstream adds a `.env` file, merge the contents but ALWAYS keep the above two variables
+- NEVER change the bakery name or hub URL to upstream values
+
+---
+
+### 2. Docker-Only Build Configuration
+
+**File: `docker.sysext/create.sh`**
+
+This fork ships **Docker ONLY** (without containerd/runc as separate components).
+
+The `populate_sysext_root()` function has been simplified to **always** remove containerd/runc:
+
+```bash
+announce "Removing containerd / runc from sysext as requested (shipping docker only)"
+
+rm "${sysextroot}/usr/bin/containerd" \
+    "${sysextroot}/usr/bin/containerd-shim-runc-v2" \
+    "${sysextroot}/usr/bin/ctr" \
+    "${sysextroot}/usr/bin/runc"
+```
+
+**What was removed:**
+- The entire conditional logic for `--without docker` or `--without containerd` options
+- The if-elif block that allowed flexible builds
+
+**Merge Rule:**
+- If upstream modifies `populate_sysext_root()`, ensure the Docker-only logic is preserved
+- NEVER reintroduce the conditional `--without` logic
+- The function should ALWAYS remove containerd/runc binaries
+
+---
+
+### 3. Deleted Containerd Files
+
+The following files were **permanently deleted** and should NEVER be restored:
+
+**Systemd Service Files:**
+- `docker.sysext/files/usr/lib/systemd/system/containerd.service`
+- `docker.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-containerd-service.conf`
+
+**Containerd Configuration Files:**
+- `docker.sysext/files/usr/share/containerd/config.toml`
+- `docker.sysext/files/usr/share/containerd/config-cgroupfs.toml`
+
+**Merge Rule:**
+- If these files appear in an upstream merge, **DELETE THEM** after the merge
+- Do NOT keep containerd as a standalone service in this fork
+
+---
+
+### 4. Default Format: EROFS
+
+**File: `lib/generate.sh`**
+
+The default filesystem format has been changed from `squashfs` to `erofs`:
+
+```bash
+local format="$(get_optional_param "format" "erofs" "${@}")"
+```
+
+**Merge Rule:**
+- If upstream modifies the `generate_sysext()` function, ensure the default format remains `erofs`
+- Original upstream value was `squashfs` - do NOT revert to this
+
+---
+
+### 5. Custom Release Versions
+
+**File: `release_build_versions.txt`**
+
+Additional versions added to the build manifest:
+
+```
+docker 28.2.1
+tailscale v1.84.0
+```
+
+**Merge Rule:**
+- When merging upstream changes to this file, preserve these specific version entries
+- If upstream adds newer versions of docker/tailscale, keep both the fork-specific versions AND the upstream versions
+- These versions may be unique to this fork's needs
+
+---
+
+## Merge Workflow Instructions
+
+When merging from upstream, follow this procedure:
+
+### Step 1: Pre-Merge Checklist
+```bash
+# Verify current fork customizations are in place
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f
+cat .env
+grep -A5 "populate_sysext_root" docker.sysext/create.sh
+grep "format" lib/generate.sh
+```
+
+### Step 2: Perform Merge
+```bash
+# Fetch and merge upstream
+git fetch upstream main
+git merge upstream/main
+```
+
+### Step 3: Post-Merge Verification
+
+After resolving conflicts, verify each protected change:
+
+#### Check 1: .env exists and is correct
+```bash
+if [[ ! -f .env ]]; then
+  echo 'bakery="darkspadez/sysext-bakery"' > .env
+  echo 'bakery_hub="sysext.darkspadez.me"' >> .env
+fi
+```
+
+#### Check 2: Docker-only logic in create.sh
+```bash
+# Ensure the file contains the Docker-only removal code
+grep -q "Removing containerd / runc from sysext as requested (shipping docker only)" docker.sysext/create.sh || echo "WARNING: Docker-only logic missing!"
+```
+
+#### Check 3: Containerd files are deleted
+```bash
+# These should all fail (files should not exist)
+test -f docker.sysext/files/usr/lib/systemd/system/containerd.service && echo "ERROR: containerd.service exists!"
+test -f docker.sysext/files/usr/share/containerd/config.toml && echo "ERROR: config.toml exists!"
+```
+
+#### Check 4: Default format is erofs
+```bash
+grep 'format="$(get_optional_param "format" "erofs"' lib/generate.sh || echo "WARNING: Default format is not erofs!"
+```
+
+#### Check 5: Custom versions present
+```bash
+grep "docker 28.2.1" release_build_versions.txt || echo "WARNING: docker 28.2.1 missing!"
+grep "tailscale v1.84.0" release_build_versions.txt || echo "WARNING: tailscale v1.84.0 missing!"
+```
+
+### Step 4: Fix Any Violations
+
+If any checks fail, manually restore the fork customizations before committing the merge.
+
+---
+
+## Conflict Resolution Guidelines
+
+### If Upstream Modified .env
+1. Accept upstream changes
+2. Add/modify to include fork-specific variables
+3. Final file must contain: `bakery="darkspadez/sysext-bakery"` and `bakery_hub="sysext.darkspadez.me"`
+
+### If Upstream Modified docker.sysext/create.sh
+1. Review upstream changes for security/bug fixes
+2. Apply those fixes but KEEP the Docker-only logic
+3. Do NOT reintroduce conditional containerd/docker build options
+4. The function must always remove: containerd, containerd-shim-runc-v2, ctr, runc
+
+### If Upstream Re-Added Containerd Files
+1. Accept the merge
+2. Delete the containerd service and config files afterward
+3. Commit with message: "Remove containerd files (fork ships Docker only)"
+
+### If Upstream Changed Default Format
+1. Review why upstream changed the format
+2. Evaluate if erofs should remain the default for this fork
+3. Unless there's a compelling reason, KEEP erofs as default
+
+### If Upstream Modified release_build_versions.txt
+1. Accept upstream additions
+2. Ensure fork-specific versions (docker 28.2.1, tailscale v1.84.0) are preserved
+3. Sort the file appropriately with both upstream and fork versions
+
+---
+
+## Commit Message Format
+
+When committing a merge that preserves fork customizations:
+
+```
+Merge upstream/main while preserving fork customizations
+
+- Kept .env with darkspadez/sysext-bakery identity
+- Preserved Docker-only build in docker.sysext/create.sh
+- Removed reintroduced containerd service files
+- Maintained erofs as default format
+- Preserved custom release versions
+
+Fork customizations from: 939ef0ac6144eeb90e1ae357d00aed3d560c118f
+```
+
+---
+
+## Emergency Recovery
+
+If fork customizations are accidentally lost, restore from the original commit:
+
+```bash
+# Restore .env
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f:.env > .env
+
+# Restore docker.sysext/create.sh changes
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f:docker.sysext/create.sh > docker.sysext/create.sh
+
+# Restore lib/generate.sh format change
+git show 939ef0ac6144eeb90e1ae357d00aed3d560c118f:lib/generate.sh > lib/generate.sh
+
+# Remove containerd files if they were restored
+rm -f docker.sysext/files/usr/lib/systemd/system/containerd.service
+rm -f docker.sysext/files/usr/lib/systemd/system/multi-user.target.d/10-containerd-service.conf
+rm -f docker.sysext/files/usr/share/containerd/config.toml
+rm -f docker.sysext/files/usr/share/containerd/config-cgroupfs.toml
+```
+
+---
+
+## Testing After Merge
+
+Before pushing merged changes, verify the build works:
+
+```bash
+# Test a build with the fork configuration
+./build.sh docker latest
+
+# Verify erofs format is used
+# Verify containerd is not included in output
+```
+
+---
+
+## Questions?
+
+If uncertain about a merge conflict or whether to preserve a customization:
+
+1. Consult this document first
+2. Check commit 939ef0ac6144eeb90e1ae357d00aed3d560c118f
+3. When in doubt, preserve the fork customization
+4. The fork's purpose is to ship **Docker-only with EROFS format** under the darkspadez identity
+
+**Always prefer preserving fork customizations over blindly accepting upstream changes.**

--- a/release_build_versions.txt
+++ b/release_build_versions.txt
@@ -33,7 +33,6 @@ docker-compose 2.22.0
 docker-compose 2.24.5
 docker-compose latest
 
-docker 28.2.1
 docker latest
 
 falco 0.39.1
@@ -73,7 +72,6 @@ rke2 v1.32.2+rke2r1
 rke2 latest
 
 tailscale v1.76.6
-tailscale v1.84.0
 tailscale latest
 
 wasmcloud v1.0.0


### PR DESCRIPTION
Created comprehensive merge strategy documentation to ensure fork
customizations from commit 939ef0ac6144eeb90e1ae357d00aed3d560c118f
are always preserved when merging upstream changes.

Added files:
- CLAUDE.md: Detailed guide for Claude AI with step-by-step merge
  procedures, validation checks, and conflict resolution strategies
- AGENTS.md: General AI agent documentation with automated merge
  procedures, decision trees, and validation rules

Protected customizations documented:
- Fork identity in .env (darkspadez/sysext-bakery)
- Docker-only build logic (no standalone containerd)
- EROFS default filesystem format (not squashfs)
- Custom release versions (docker 28.2.1, tailscale v1.84.0)
- Deleted containerd service/config files

These documents provide clear rules for:
- Pre-merge validation
- Conflict resolution strategies
- Post-merge verification
- Automatic fix procedures
- Emergency recovery steps

Ensures fork maintains its core purpose: Docker-only builds with
EROFS format under darkspadez identity.